### PR TITLE
change windows behavior to not fire on handled exs

### DIFF
--- a/src/segfault-handler.cpp
+++ b/src/segfault-handler.cpp
@@ -326,7 +326,7 @@ NAN_METHOD(RegisterHandler) {
   }
 
   #ifdef _WIN32
-    AddVectoredExceptionHandler(1, segfault_handler);
+    SetUnhandledExceptionFilter(segfault_handler);
   #else
     struct sigaction sa;
     memset(&sa, 0, sizeof(struct sigaction));


### PR DESCRIPTION
same as [this](https://github.com/ddopson/node-segfault-handler/pull/79#issue-687025634)